### PR TITLE
Add "enabled" flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ running at least Java 11 and access to the project source code.
 
 Gradle:
 ```groovy
-api 'com.brightspot:recordsync:1.0.0'
+api 'com.brightspot:recordsync:1.1.0'
 ```
 
 Maven:
@@ -29,11 +29,11 @@ Maven:
 <dependency>
     <groupId>com.brightspot</groupId>
     <artifactId>recordsync</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
-Substitute `1.0.0` for the desired version found on the [releases](../../releases) list.
+Substitute `1.1.0` for the desired version found on the [releases](../../releases) list.
 
 ## Usage
 
@@ -123,6 +123,11 @@ specific to the environment on which they were created.
     <Environment name="brightspot/recordsync/exporters/primary/taskHost"
                  value="task-server.local"
                  type="java.lang.String"/>
+    <!-- Enabled flag. If unspecified, the task will be enabled. Set it to
+         "false" to disable. -->
+    <Environment name="brightspot/recordsync/exporters/primary/enabled"
+                 value="true"
+                 type="java.lang.String"/>
     <!-- The maximum size in MB of each export file (before compression).
          Note that each entire file is processed in memory one at a time, so
          keep this relatively small.
@@ -182,6 +187,11 @@ specific to the environment on which they were created.
          this import. Required. -->
     <Environment name="brightspot/recordsync/importers/primary/taskHost"
                  value="task-server.local"
+                 type="java.lang.String"/>
+    <!-- Enabled flag. If unspecified, the task will be enabled. Set it to
+         "false" to disable. -->
+    <Environment name="brightspot/recordsync/importers/primary/enabled"
+                 value="true"
                  type="java.lang.String"/>
     <!-- Maximum number of records to import in a single transaction; The
          default is 500. -->

--- a/src/main/java/brightspot/recordsync/RecordSyncImportTaskSettings.java
+++ b/src/main/java/brightspot/recordsync/RecordSyncImportTaskSettings.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *     <li>brightspot/recordsync/importers/[NAME]/taskHost=job.brightspot // The host name or ip address of the tomcat instance that will execute this task. Required.
  *     <li>brightspot/recordsync/importers/[NAME]/storage=example-project-ops // Reference to a dari/storage setting. Required.
  *     <li>brightspot/recordsync/importers/[NAME]/pathPrefix=recordsync // Appended to the storage base path. Required.
- *     <li>brightspot/recordsync/exporters/[NAME]/enabled=true // Enabled flag. If all other settings are valid, the default is true.
+ *     <li>brightspot/recordsync/importers/[NAME]/enabled=true // Enabled flag. If all other settings are valid, the default is true.
  *     <li>brightspot/recordsync/importers/[NAME]/batchSize=200 // Maximum number of records to import at a time; Default is {@link #DEFAULT_BATCH_SIZE}.
  *     <li>brightspot/recordsync/importers/[NAME]/excludedTypes=com.psddev.cms.db.ToolEntity,com.psddev.cms.db.SiteSettings // Comma-separated type names to exclude from this import. There are already reasonable defaults in place; this adds to that set. Optional.
  *     <li>brightspot/recordsync/importers/[NAME]/includedTypes=com.psddev.cms.db.ToolEntity,com.psddev.cms.db.SiteSettings // Comma-separated type names to include in this import. Optional.


### PR DESCRIPTION
This addresses issue #1.

In order to maintain backwards compatibility, the default value of the
"enabled" flag is true.

When "enabled=false," you'll see an info message in the log like this:

```
brightspot.recordsync.RecordSyncImportTaskSettings.initialize
Record Sync Import task [primary] is not enabled, otherwise it would run [every Friday at 12:00 am] on [your-task-host.brightspot].
```

```
brightspot.recordsync.RecordSyncExportTaskSettings.initialize
Record Sync Export task [primary] is not enabled, otherwise it would run [every Friday at 10:00 pm] on [your-task-host.brightspot]
```